### PR TITLE
CFLCompanionDlg::OnDumpSolutions: Add missing quote following travel time

### DIFF
--- a/FLCompanionDlg.cpp
+++ b/FLCompanionDlg.cpp
@@ -1909,7 +1909,7 @@ void CFLCompanionDlg::OnDumpSolutions()
 								file.WriteString(IntToString(profit));
 								file.WriteString(L",\"");
 								file.WriteString(MinuteSeconds(distance, true));
-								file.WriteString(L",");
+								file.WriteString(L"\",");
 
 								TCHAR buf[32];
 								if (m_cargoSize == 1)


### PR DESCRIPTION
So we're not producing invalid CSVs.