### PR TITLE
Use the sell price, kept in the 'min' value on MarketGood entries

### DIFF
--- a/BaseInfoDlg.cpp
+++ b/BaseInfoDlg.cpp
@@ -94,7 +94,7 @@ BOOL CBaseInfoDlg::OnInitDialog()
 		int nIndex = m_baseCombo.AddString(base.m_caption+L", "+base.m_system->m_caption+L" System");
 		m_baseCombo.SetItemDataPtr(nIndex, &base);
 	}
-	// m_baseCombo est triée par ordre alphabetique
+	// m_baseCombo est triï¿½e par ordre alphabetique
 	int nIndex = 0;
 	void *data;
 	while ((data = m_baseCombo.GetItemDataPtr(nIndex)) != (void*) CB_ERR)
@@ -173,8 +173,9 @@ BOOL CBaseInfoDlg::LoadBaseMarkets(const CString &iniFilename)
 				//
 				// iniFile.GetValueInt(values,2) : Minimum faction level to purchase (can be decimal)
 				//		-1 = even if very hostile, 0 = must be at least neutral, 1 = need to be very friendly
-				UINT buyonly = iniFile.GetValueInt(values,5);
-				if (buyonly)
+				UINT min = iniFile.GetValueInt(values, 3);
+				UINT stock = iniFile.GetValueInt(values,4);
+				if (!stock && !min)
 					continue; // we want to list only goods that are sold here
 				if (g_goodsByNick.Contains(name)) // is it a commodity ?
 				{

--- a/BaseInfoDlg.cpp
+++ b/BaseInfoDlg.cpp
@@ -175,7 +175,7 @@ BOOL CBaseInfoDlg::LoadBaseMarkets(const CString &iniFilename)
 				//		-1 = even if very hostile, 0 = must be at least neutral, 1 = need to be very friendly
 				UINT min = iniFile.GetValueInt(values, 3);
 				UINT stock = iniFile.GetValueInt(values,4);
-				if (!stock && !min)
+				if (!stock)
 					continue; // we want to list only goods that are sold here
 				if (g_goodsByNick.Contains(name)) // is it a commodity ?
 				{

--- a/Datas.cpp
+++ b/Datas.cpp
@@ -435,25 +435,27 @@ BOOL LoadMarketPrices(const CString &iniFilename)
 				//
 				// iniFile.GetValueInt(values,2) : Minimum faction level to purchase (can be decimal)
 				//		-1 = even if very hostile, 0 = must be at least neutral, 1 = need to be very friendly
-				UINT buyonly = iniFile.GetValueInt(values,5);
-				if ((buyonly != 0) && (buyonly != 1)) ProblemFound(L"MarketGood entry (%s on %s) with 6th value (buy only) different than 0 or 1 (%d)", name, base.m_nickname, buyonly);
-				float price = (good.m_defaultPrice*iniFile.GetValueFloat(values,6));
-				if(price < 1)
-					ProblemFound(L"MarketGood entry (%s, %s) with value less than 1 credit in %s", base.m_nickname, name, iniFilename);
-				//if (base.m_buy[good] != 0) ProblemFound(L"MarketGood entry (%s on %s) is defined twice", name, base.m_nickname);
+				UINT min = iniFile.GetValueInt(values,3);
+				UINT stock = iniFile.GetValueInt(values, 4);
+				float buyPrice = (good.m_defaultPrice*iniFile.GetValueFloat(values,6));
+				float sellPricePrice = static_cast<float>(min);
+				if(buyPrice < 1)
+					ProblemFound(L"MarketGood entry (%s, %s) with buy price less than 1 credit in %s", base.m_nickname, name, iniFilename);
+				if (sellPricePrice < 1)
+					ProblemFound(L"MarketGood entry (%s, %s) with sell price less than 1 credit in %s", base.m_nickname, name, iniFilename);
 				
-				if (buyonly)
+				if (!min && !stock)
 				{
 					if ((iniFile.GetValueInt(values,3) != 0) || (iniFile.GetValueInt(values,4) != 0)) ProblemFound(L"MarketGood buy-only entry (%s on %s) with 4th or 5th value different than 0", name, base.m_nickname);
-					base.m_buy[good] = price;
+					base.m_buy[good] = buyPrice;
 					base.m_sell[good] = FLT_MAX;
 				}
 				else
 				{
 					//CHECK((iniFile.GetValueInt(values,3) == 150) && (iniFile.GetValueInt(values,4) == 500));
 					//	supposedly: number of items in stock (but not implemented in game)
-					base.m_buy[good] = price;
-					base.m_sell[good] = price;
+					base.m_buy[good] = buyPrice;
+					base.m_sell[good] = sellPricePrice;
 					if (!base.m_hasSell)
 					{
 						base.m_hasSell = true;

--- a/Datas.cpp
+++ b/Datas.cpp
@@ -11,6 +11,7 @@
 #include <ShObjIdl.h>
 #include <math.h>
 #include "Faction.h"
+#include <locale>
 
 _COM_SMARTPTR_TYPEDEF(IFileOpenDialog, IID_IFileOpenDialog);
 
@@ -1108,6 +1109,7 @@ void DetectMod()
 
 BOOL LoadAppDatas(CWnd *wnd)
 {
+	std::setlocale(LC_ALL, "en-US");
 	g_flAppPath = theApp.GetProfileString(L"Settings", L"FLPath");
 	if (g_flAppPath.IsEmpty() || !PathFileExists(g_flAppPath+L"\\EXE\\Freelancer.exe"))
 	{

--- a/Datas.cpp
+++ b/Datas.cpp
@@ -437,12 +437,14 @@ BOOL LoadMarketPrices(const CString &iniFilename)
 				//		-1 = even if very hostile, 0 = must be at least neutral, 1 = need to be very friendly
 				UINT min = iniFile.GetValueInt(values,3);
 				UINT stock = iniFile.GetValueInt(values, 4);
-				float buyPrice = (good.m_defaultPrice*iniFile.GetValueFloat(values,6));
-				float sellPricePrice = static_cast<float>(min);
+				float defPrice = good.m_defaultPrice;
+				float baseMult = iniFile.GetValueFloat(values, 6);
+				float buyPrice = defPrice * baseMult;
+				float sellPrice = static_cast<float>(min);
 				if(buyPrice < 1)
-					ProblemFound(L"MarketGood entry (%s, %s) with buy price less than 1 credit in %s", base.m_nickname, name, iniFilename);
-				if (sellPricePrice < 1)
-					ProblemFound(L"MarketGood entry (%s, %s) with sell price less than 1 credit in %s", base.m_nickname, name, iniFilename);
+					ProblemFound(L"MarketGood entry (%s, %s) with buy price less than 1 credit in %s, default price %0.0f, mult %0.2f", base.m_nickname, name, iniFilename, good.m_defaultPrice, baseMult);
+				if (sellPrice < 1)
+					ProblemFound(L"MarketGood entry (%s, %s) with sell price less than 1 credit in %s, price: 0.0f", base.m_nickname, name, iniFilename, sellPrice);
 				
 				if (!min && !stock)
 				{
@@ -455,7 +457,7 @@ BOOL LoadMarketPrices(const CString &iniFilename)
 					//CHECK((iniFile.GetValueInt(values,3) == 150) && (iniFile.GetValueInt(values,4) == 500));
 					//	supposedly: number of items in stock (but not implemented in game)
 					base.m_buy[good] = buyPrice;
-					base.m_sell[good] = sellPricePrice;
+					base.m_sell[good] = sellPrice;
 					if (!base.m_hasSell)
 					{
 						base.m_hasSell = true;

--- a/Datas.cpp
+++ b/Datas.cpp
@@ -439,16 +439,16 @@ BOOL LoadMarketPrices(const CString &iniFilename)
 				UINT stock = iniFile.GetValueInt(values, 4);
 				float defPrice = good.m_defaultPrice;
 				float baseMult = iniFile.GetValueFloat(values, 6);
-				float buyPrice = defPrice * baseMult;
-				float sellPrice = static_cast<float>(min);
+				float sellPrice = defPrice * baseMult;
+				float buyPrice = static_cast<float>(min);
 				if(buyPrice < 1)
 					ProblemFound(L"MarketGood entry (%s, %s) with buy price less than 1 credit in %s, default price %0.0f, mult %0.2f", base.m_nickname, name, iniFilename, good.m_defaultPrice, baseMult);
 				if (sellPrice < 1)
 					ProblemFound(L"MarketGood entry (%s, %s) with sell price less than 1 credit in %s, price: 0.0f", base.m_nickname, name, iniFilename, sellPrice);
 				
-				if (!min && !stock)
+				if (stock == 0)
 				{
-					if ((iniFile.GetValueInt(values,3) != 0) || (iniFile.GetValueInt(values,4) != 0)) ProblemFound(L"MarketGood buy-only entry (%s on %s) with 4th or 5th value different than 0", name, base.m_nickname);
+					//if ((iniFile.GetValueInt(values,3) != 0) || (iniFile.GetValueInt(values,4) != 0)) ProblemFound(L"MarketGood buy-only entry (%s on %s) with 4th or 5th value different than 0", name, base.m_nickname);
 					base.m_buy[good] = buyPrice;
 					base.m_sell[good] = FLT_MAX;
 				}

--- a/DynEconDlg.cpp
+++ b/DynEconDlg.cpp
@@ -173,20 +173,27 @@ UINT CGameInspect::CollectGoodPrice(DWORD id, LPVOID ptr)
 	if (m_idGoodMap.Lookup(id, goodIndex))
 	{
 		result = MAKELONG(1, 0);
-		if (m_base->m_buy[goodIndex] != goodData.fPrice)
+		if (m_base->m_buy[goodIndex] != static_cast<float>(goodData.iStock1))
 			result = MAKELONG(1, 1);
-		m_base->m_buy[goodIndex] = goodData.fPrice;
-		float sellPrice = (goodData.iTransType == TransactionType_Sell) ? goodData.fPrice : FLT_MAX;
+		m_base->m_buy[goodIndex] = static_cast<float>(goodData.iStock1);
+		float sellPrice = goodData.fPrice;
 		if (m_base->m_sell[goodIndex] != sellPrice)
 			result = MAKELONG(1, 1);
 		m_base->m_sell[goodIndex] = sellPrice;
 
 		if (sellPrice < 1)
 			ProblemFound(L"Client-Imported MarketGood entry (%s, %s) with value less than 1 credit from server", m_base->m_nickname, g_goods[goodIndex].m_nickname);
-		if ((goodData.iTransType == TransactionType_Sell) && !m_base->m_hasSell)
+		if (goodData.iStock2)
 		{
-			m_base->m_hasSell = true;
-			m_base->m_system->m_hasSell = true;
+			if(!m_base->m_hasSell)
+			{
+				m_base->m_hasSell = true;
+				m_base->m_system->m_hasSell = true;
+			}
+		}
+		else
+		{
+			m_base->m_sell[goodIndex] = FLT_MAX;
 		}
 	}
 	return result;
@@ -221,9 +228,9 @@ UINT CGameInspect::TreeForEach(FlTree& tree, UINT (CGameInspect::*callback)(DWOR
 	FlNode* nodeNil = tree._Nil;
 	FlNode node;
 	READFLMEM(node, tree._Head);
-	// marketNode._Left  = feuille la plus à gauche
+	// marketNode._Left  = feuille la plus ï¿½ gauche
 	// marketNode._Parent= sommet de l'arbre
-	// marketNode._Right = feuille la plus à droite
+	// marketNode._Right = feuille la plus ï¿½ droite
 	if (node._Parent != nodeNil)
 		return TreeForEachRecurse(node._Parent, nodeNil, callback);
 	return 0;
@@ -533,7 +540,7 @@ UINT CGameInspect::FoundPlayer(DWORD id, LPVOID ptr)
 
 
 
-// 673320 IdsTree (mélange de FactionID et FLHash) { BYTE flags; }
+// 673320 IdsTree (mï¿½lange de FactionID et FLHash) { BYTE flags; }
 // 61226C
 
 // 64018EC: tree des groups?

--- a/FLCompanionDlg.cpp
+++ b/FLCompanionDlg.cpp
@@ -680,7 +680,7 @@ void CFLCompanionDlg::AddSolution(int goodIndex, double destbuy, double srcsell,
 		CString ratio = DoubleToString(calcCSU*units);
 		int index = ratio.Find('.');
 		if (index > 0) ratio = ratio.Left(index + 3);
-		_stprintf(buf, L"%s ¢/sec", LPCTSTR(ratio));
+		_stprintf(buf, L"%s c/sec", LPCTSTR(ratio));
 	}
 	else
 	{
@@ -694,9 +694,9 @@ void CFLCompanionDlg::AddSolution(int goodIndex, double destbuy, double srcsell,
 	CString ratio = DoubleToString(calcCSU);
 	int index = ratio.Find('.');
 	if (index > 0) ratio = ratio.Left(index + 3);
-	_stprintf(buf, L"%s ¢/sec", LPCTSTR(ratio));
+	_stprintf(buf, L"%s c/sec", LPCTSTR(ratio));
 
-	//_stprintf(buf, L"%d ¢/sec", "");
+	//_stprintf(buf, L"%d c/sec", "");
 	m_routes.SetItemText(nItem, 8, buf);
 	_stprintf(buf, L"%d", goodIndex);
 	m_routes.SetItemText(nItem, 6, buf);
@@ -2295,7 +2295,7 @@ void CFLCompanionDlg::Calc_TotalRow()
 		//m_routes.SetItemText(nItem, 4, MinuteSeconds(distance, true));
 		if (m_cargoSize == 1)
 		{
-			//_stprintf(buf, L"%d ¢/sec", profit * 100000 / distance);
+			//_stprintf(buf, L"%d c/sec", profit * 100000 / distance);
 		}
 		else
 		{
@@ -2317,7 +2317,7 @@ void CFLCompanionDlg::Calc_TotalRow()
 	m_traderoute.SetItemText(g_traderouteTotal, 4, MinuteSeconds(t_distance, true));
 	if (m_cargoSize == 1)
 	{
-		_stprintf(buf, L"%d ¢/sec", t_profit * 100000 / t_distance);
+		_stprintf(buf, L"%d c/sec", t_profit * 100000 / t_distance);
 	}
 	else
 	{
@@ -2330,7 +2330,7 @@ void CFLCompanionDlg::Calc_TotalRow()
 	CString ratio = DoubleToString((t_profit / m_cargoSize) * 100000.00 / t_distance);
 	int index = ratio.Find('.');
 	if (index > 0) ratio = ratio.Left(index + 3);
-	_stprintf(buf, L"%s ¢/sec", LPCTSTR(ratio));
+	_stprintf(buf, L"%s c/sec", LPCTSTR(ratio));
 	m_traderoute.SetItemText(g_traderouteTotal, 8, buf);
 	g_traderouteTotalHour = m_traderoute.InsertItem(MAXLONG, L"Approx. per Hour : ");
 

--- a/FLCompanionDlg.cpp
+++ b/FLCompanionDlg.cpp
@@ -680,7 +680,7 @@ void CFLCompanionDlg::AddSolution(int goodIndex, double destbuy, double srcsell,
 		CString ratio = DoubleToString(calcCSU*units);
 		int index = ratio.Find('.');
 		if (index > 0) ratio = ratio.Left(index + 3);
-		_stprintf(buf, L"%s c/sec", LPCTSTR(ratio));
+		_stprintf(buf, L"%s ¢/sec", LPCTSTR(ratio));
 	}
 	else
 	{
@@ -694,9 +694,9 @@ void CFLCompanionDlg::AddSolution(int goodIndex, double destbuy, double srcsell,
 	CString ratio = DoubleToString(calcCSU);
 	int index = ratio.Find('.');
 	if (index > 0) ratio = ratio.Left(index + 3);
-	_stprintf(buf, L"%s c/sec", LPCTSTR(ratio));
+	_stprintf(buf, L"%s ¢/sec", LPCTSTR(ratio));
 
-	//_stprintf(buf, L"%d c/sec", "");
+	//_stprintf(buf, L"%d ¢/sec", "");
 	m_routes.SetItemText(nItem, 8, buf);
 	_stprintf(buf, L"%d", goodIndex);
 	m_routes.SetItemText(nItem, 6, buf);
@@ -2295,7 +2295,7 @@ void CFLCompanionDlg::Calc_TotalRow()
 		//m_routes.SetItemText(nItem, 4, MinuteSeconds(distance, true));
 		if (m_cargoSize == 1)
 		{
-			//_stprintf(buf, L"%d c/sec", profit * 100000 / distance);
+			//_stprintf(buf, L"%d ¢/sec", profit * 100000 / distance);
 		}
 		else
 		{
@@ -2317,7 +2317,7 @@ void CFLCompanionDlg::Calc_TotalRow()
 	m_traderoute.SetItemText(g_traderouteTotal, 4, MinuteSeconds(t_distance, true));
 	if (m_cargoSize == 1)
 	{
-		_stprintf(buf, L"%d c/sec", t_profit * 100000 / t_distance);
+		_stprintf(buf, L"%d ¢/sec", t_profit * 100000 / t_distance);
 	}
 	else
 	{
@@ -2330,7 +2330,7 @@ void CFLCompanionDlg::Calc_TotalRow()
 	CString ratio = DoubleToString((t_profit / m_cargoSize) * 100000.00 / t_distance);
 	int index = ratio.Find('.');
 	if (index > 0) ratio = ratio.Left(index + 3);
-	_stprintf(buf, L"%s c/sec", LPCTSTR(ratio));
+	_stprintf(buf, L"%s ¢/sec", LPCTSTR(ratio));
 	m_traderoute.SetItemText(g_traderouteTotal, 8, buf);
 	g_traderouteTotalHour = m_traderoute.InsertItem(MAXLONG, L"Approx. per Hour : ");
 

--- a/FLCompanionDlg.cpp
+++ b/FLCompanionDlg.cpp
@@ -745,8 +745,8 @@ void CFLCompanionDlg::AddSolutionsForBase(CBase* base)
 					continue;
 				double destbuy = max(destbase->m_buy[goodIndex], 1);
 				double srcsell = max(sell[goodIndex], 1);
-				if (destbase->m_buy[goodIndex] > sell[goodIndex]) // destination buying price is higher than initial sell price
-					AddSolution(goodIndex, destbuy, srcsell, base, destbase, g_jumptrade ? m_jumptradeTime : 
+				if (destbuy > srcsell) // destination buying price is higher than initial sell price
+					AddSolution(goodIndex, destbuy, srcsell, base, destbase, g_jumptrade ? m_jumptradeTime :
 						base->m_distanceToBase[destbase-g_bases]+base->GetDockingDelay());
 						//base.m_system->m_distances[destbase->m_system-g_systems]);
 			}


### PR DESCRIPTION
Discovery Patch 5.1 and it's updated FLHook causes the client to display the value kept in the 'min' variable on MarketGood (4rd value).

Detection of base actually selling the commodity also updated to check if both Min and Stock (4th and 5th variables) are positive, which reflects the actual game logic.